### PR TITLE
Fix Media3 transformer sequence API compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.1
+
+* Updated Android Media3 dependencies to 1.9.2.
+* Fixed Android video transformation crashes caused by the removed `EditedMediaItemSequence(List)` constructor.
+
 ## 1.2.0
 
 * Added iOS support.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ allprojects {
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
-def media3Version = "1.7.1"
+def media3Version = "1.9.2"
 
 android {
     namespace = "com.example.lut_transformer"

--- a/android/src/main/kotlin/com/example/lut_transformer/VideoTransformer.kt
+++ b/android/src/main/kotlin/com/example/lut_transformer/VideoTransformer.kt
@@ -138,9 +138,8 @@ object VideoTransformer {
                 .setEffects(effects)
                 .build()
 
-            val editedMediaItemSequence = EditedMediaItemSequence(listOf(editedMediaItem))
-            // For concatenating multiple clips, add more EditedMediaItem to the list above,
-            // or add more EditedMediaItemSequence to the compositionBuilder list.
+            val editedMediaItemSequence =
+                EditedMediaItemSequence.withAudioAndVideoFrom(listOf(editedMediaItem))
             val composition = Composition.Builder(listOf(editedMediaItemSequence)).build()
 
             val outputVideoFile = File(context.cacheDir, "transformed_${UUID.randomUUID()}.mp4")

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -301,7 +301,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.2.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lut_transformer
 description: "A Flutter plugin to apply 3D LUT (.cube) filters to videos on Android. Transforms video colors based on a provided LUT file and allows adjusting LUT intensity."
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/nomuman/lut_transformer
 repository: https://github.com/nomuman/lut_transformer 
 issue_tracker: https://github.com/nomuman/lut_transformer/issues 


### PR DESCRIPTION
## Summary
- update Android Media3 dependencies to 1.9.2
- replace the removed EditedMediaItemSequence(List) constructor with withAudioAndVideoFrom(...)
- bump package version to 1.2.1

## Verification
- flutter analyze
- flutter build apk --debug from example